### PR TITLE
Make package installable from git

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "precoveragehtml": "npm run coverage",
     "coveragehtml": "nyc report -r html",
     "predev": "if [ ! -f coverage/index.html ]; then mkdir coverage; cp .waiting.html coverage/index.html; fi",
-    "coveralls": "nyc report --reporter=text-lcov | coveralls"
+    "coveralls": "nyc report --reporter=text-lcov | coveralls",
+    "prepack": "npm install"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The `prepack` script will be called by npm after pulling from git and before moving everything (minus everything ignored by `.npmignore`) into `node_modules`